### PR TITLE
サンプル用のプロジェクトは、pipインストール時に除外するように

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,3 @@ include requirements.txt
 recursive-include blog/static *
 recursive-include blog/templates *
 recursive-include docs *
-prune project

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name='django-torina-blog',
     version='0.5',
-    packages=find_packages(),
+    packages=find_packages(exclude=("project",)),
     include_package_data=True,
     license='MIT License',  # example license
     description='Django Blog App',


### PR DESCRIPTION
find_packages(exclude=("project",))
で除外できるのをしりませんでした。